### PR TITLE
Updated readme to ensure platform flag is included when executing

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The simplest way to install `swiftrsrc` is to download the latest binary from th
 ### Usage
 
 ```swift
-swiftrsrc generate [--platform osx|ios] input_path output_path
+swiftrsrc generate --platform [osx|ios] input_path output_path
 ```
 
 **_[--platform ios|osx]_**  

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The simplest way to install `swiftrsrc` is to download the latest binary from th
 swiftrsrc generate --platform [osx|ios] input_path output_path
 ```
 
-**_[--platform ios|osx]_**  
+**_--platform [ios|osx]_**  
 platform to generate code for. Must be either "ios" or "osx"
 
 **_input_path_**  


### PR DESCRIPTION
Just a tiny PR here - I struggled to understand what I was doing wrong, until a colleague pointed out I excluded the required platform flag. I think this change makes it more explicit. 